### PR TITLE
Add carry weight and notifications override

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/FoundryVTT-fallout-fr.iml
+++ b/.idea/FoundryVTT-fallout-fr.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="foundry-vtt-fallout-2d20-french" />
+    <orderEntry type="module" module-name="fallout" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/FoundryVTT-fallout-fr.iml" filepath="$PROJECT_DIR$/.idea/FoundryVTT-fallout-fr.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../fallout/.idea/fallout.iml" filepath="$PROJECT_DIR$/../fallout/.idea/fallout.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../foundry-vtt-fallout-2d20-french/.idea/foundry-vtt-fallout-2d20-french.iml" filepath="$PROJECT_DIR$/../foundry-vtt-fallout-2d20-french/.idea/foundry-vtt-fallout-2d20-french.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../fallout" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../foundry-vtt-fallout-2d20-french" vcs="Git" />
+  </component>
+</project>

--- a/fr.json
+++ b/fr.json
@@ -199,7 +199,21 @@
     "SPECIAL_ABILITY": "Aptitude spéciale",
     "INVENTORY": "Inventaire",
     "stashed": "Caché",
-    "favorite": "Favoris"
+    "favorite": "Favoris",
+    "NOTIFICATIONS": {
+      "ONLY_PLAYERS_CAN_HAVE_PERKS": "Les aptitudes sont réservées aux PJs",
+      "ONLY_CHARACTERS_CAN_HAVE_DISEASE": "Seuls les PJs non-robots peuvent être malades",
+      "ONLY_NPCs_AND_CREATURES_CAN_HAVE_SPECIAL_ABILITIES": "Les capacités spéciales sont réservées aux PNJs et créatures",
+      "Select_Dice_you_want_to_Reroll": "Choisissez les dés à relancer",
+      "No_dice_face_reckognized": "Type de dé non reconnu",
+      "THERE_IS_ALREADY_A_SKILL_WITH_THAT_NAME": "Une compétence porte déjà ce nom",
+      "Adding_Item_Macro:_This_feature_is_to_be_added_in_the_future": "Cette fonctionnalité n'est pas encore disponible",
+      "You_can_only_create_macro_buttons_for_owned_Items": "Vous ne pouvez créer de bouton de macro que pour les objets que vous possédez",
+      "To_be_added_in_the_future": "Cette fonctionnalité n'est pas encore disponible",
+      "Managing_Active_Effects_within_an_Owned_Item_is_not_currently_supported_and_will_be_added_in_a_subsequent_update.": "Cette fonctionnalité n'est pas encore disponible",
+      "Ammo_not_found": "Pas de munitions de ce type",
+      "Not_enough_ammo": "Pas assez de munitions de ce type"
+    }
   },
   "FALLOUT.TEMPLATES": {
     "OVERSEER_AP": "P.A. DU MENEUR",

--- a/module.json
+++ b/module.json
@@ -32,7 +32,10 @@
       }
     ]
   },
-  "esmodules": ["babele-register.js"],
+  "esmodules": [
+    "override-carry-weight.js",
+    "babele-register.js"
+  ],
   "styles": ["css/fallout.css"],
   "languages": [
     {

--- a/module.json
+++ b/module.json
@@ -34,6 +34,7 @@
   },
   "esmodules": [
     "override-carry-weight.js",
+    "override-ui-notifications.js",
     "babele-register.js"
   ],
   "styles": ["css/fallout.css"],

--- a/override-carry-weight.js
+++ b/override-carry-weight.js
@@ -1,0 +1,39 @@
+Hooks.once('init', () => {
+    if(typeof libWrapper !== 'undefined') {
+        /**
+         * Converter to handle lbs to kg conversion in the ActorSheet for characters
+         */
+        libWrapper.register('fallout-fr', 'game.fallout.FalloutActor.prototype._prepareCharacterData', function (wrapped, ...args) {
+            wrapped(...args);
+
+            if (this.type !== 'character') {
+                return
+            }
+
+            // Encumbrance
+            this.system.carryWeight.base -= (parseInt(this.system.attributes.str.value) * 5)
+            this.system.carryWeight.value = this.system.carryWeight.base + parseInt(this.system.carryWeight.mod)
+
+            if (this.system.carryWeight.total > this.system.carryWeight.value) {
+                let dif = this.system.carryWeight.total - this.system.carryWeight.value
+                this.system.encumbranceLevel = Math.ceil(dif / 25)
+            }
+        }, 'MIXED');
+
+        /**
+         * Converter to handle lbs to kg conversion in the ActorSheet for robots
+         */
+        libWrapper.register('fallout-fr', 'game.fallout.FalloutActor.prototype._prepareRobotData', function (wrapped, ...args) {
+            wrapped(...args);
+
+            if (this.type !== 'robot') {
+                return
+            }
+
+            if (this.system.carryWeight.total > this.system.carryWeight.value) {
+                let dif = this.system.carryWeight.total - this.system.carryWeight.value
+                this.system.encumbranceLevel = Math.ceil(dif / 25)
+            }
+        }, 'MIXED');
+    }
+});

--- a/override-ui-notifications.js
+++ b/override-ui-notifications.js
@@ -1,0 +1,31 @@
+/**
+ * Try to map a message into a translation key to translate notifications without modifying original system's code
+ *
+ * @param wrapped
+ * @param args
+ * @returns {*}
+ */
+function localizeUiNotification(wrapped, ...args) {
+    let key = "FALLOUT.UI.NOTIFICATIONS."
+
+    if (args[0].startsWith("Ammo ") && args[0].endsWith(" not found")) {
+        key += "Ammo_not_found"
+    } else if (args[0].startsWith("Not enough ") && args[0].endsWith(" ammo")) {
+        key += "Not_enough_ammo"
+    } else {
+        key += `${args[0].replace(/\s+/g, '_')}`;
+    }
+
+    if (game.i18n.has(key)) {
+        args[0] = game.i18n.localize(key)
+    }
+
+    return wrapped(...args)
+}
+
+Hooks.once('ready', () => {
+    if(typeof libWrapper !== 'undefined') {
+        libWrapper.register('fallout-fr', 'ui.notifications.notify', localizeUiNotification)
+        libWrapper.register('fallout-fr', 'ui.notifications.warn', localizeUiNotification)
+    }
+});


### PR DESCRIPTION
Hello !

Petite proposition pour intégrer deux fonctionnalités au module de traduction : 

- Le passage des livres aux kilos pour le calcul de l'encombrement
- La traduction des notifications

J'ai laissé de côté la traduction des placeholders (le texte par défaut des champs texte, comme pour origine dans la fiche de perso) qui posaient de gros soucis de mise à jour.